### PR TITLE
Remove "vendor_data_len" from VendorSpecificInfo

### DIFF
--- a/pyieee1905/ieee1905_tlv.py
+++ b/pyieee1905/ieee1905_tlv.py
@@ -311,7 +311,7 @@ class WSC(IEEE1905_TLV):
         XByteField("type", 0x11),
         XShortField("len", None),
         FieldListField("wsc_frame", None, XByteField("byte", None),
-                       count_from=lambda p:p.wsc_frame_size)
+                       length_from=lambda p:len(p.wsc_frame))
     ]
 
 

--- a/pyieee1905/ieee1905_tlv.py
+++ b/pyieee1905/ieee1905_tlv.py
@@ -310,7 +310,6 @@ class WSC(IEEE1905_TLV):
     fields_desc = [
         XByteField("type", 0x11),
         XShortField("len", None),
-        FieldLenField("wsc_frame_size", None, count_of="wsc_frame"),
         FieldListField("wsc_frame", None, XByteField("byte", None),
                        count_from=lambda p:p.wsc_frame_size)
     ]

--- a/pyieee1905/ieee1905_tlv.py
+++ b/pyieee1905/ieee1905_tlv.py
@@ -246,7 +246,6 @@ class VendorSpecific(IEEE1905_TLV):
         XByteField("type", 0x0B),
         XShortField("len", None),
         X3BytesField("vendor_oui", None),
-        FieldLenField("vendor_data_len", None, fmt='B', count_of="vendor_data"),
         FieldListField("vendor_data", None, XByteField("byte", None),
                        count_from=lambda p:p.vendor_data_len)
     ]

--- a/pyieee1905/multiap_tlv.py
+++ b/pyieee1905/multiap_tlv.py
@@ -945,3 +945,17 @@ class ChannelScanCapabilities(IEEE1905_TLV):
         PacketListField("radio_list", None, ChannelScanCapabilities_Radio,
                 count_from=lambda p:p.radio_cnt)
     ]
+
+# Unsuccessful Association Policy TLV (0xC4)
+class UnsuccessfulAssociationPolicy(IEEE1905_TLV):
+    name = "Unsuccessful Association Policy TLV"
+    fields_desc = [
+        XByteField("type", 0xC4),
+        XShortField("len", None),
+        BitField("report_unsuccessful_associations_flag", 0, 1),
+        BitField("reserved", 0, 7),
+        IntField("maximum_reporting_rate", 0)
+    ]
+
+    def extract_padding(self, s):
+        return "", s


### PR DESCRIPTION
There is no "vendor_data_len" according to IEEE 1905.1-2013 "Table 5-20—VendorSpecificInfo information element" (page 27).